### PR TITLE
bypass operator family

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -119,7 +119,8 @@ module Apartment
 
       PSQL_DUMP_BLACKLISTED_STATEMENTS= [
         /SET search_path/i,   # overridden later
-        /SET lock_timeout/i   # new in postgresql 9.3
+        /SET lock_timeout/i,   # new in postgresql 9.3
+        /CREATE OPERATOR FAMILY/i # bypass operator family because we don't have permission on RDS.
       ]
 
       def import_database_schema


### PR DESCRIPTION
Bypassing operator family because we don't have permission on RDS. Schema creation fails without this change.